### PR TITLE
防止系列帧中出现了宽高为0的情况

### DIFF
--- a/awebp/src/main/java/com/github/penfeizhou/animation/webp/decode/WebPDecoder.java
+++ b/awebp/src/main/java/com/github/penfeizhou/animation/webp/decode/WebPDecoder.java
@@ -8,6 +8,7 @@ import android.graphics.Paint;
 import android.graphics.PorterDuff;
 import android.graphics.PorterDuffXfermode;
 import android.graphics.Rect;
+import android.util.Log;
 
 import com.github.penfeizhou.animation.decode.Frame;
 import com.github.penfeizhou.animation.decode.FrameSeqDecoder;
@@ -112,10 +113,16 @@ public class WebPDecoder extends FrameSeqDecoder<WebPReader, WebPWriter> {
 
     @Override
     protected void renderFrame(Frame frame) {
-        if (frame == null) {
+        if (frame == null || fullRect == null) {
+            return;
+        }
+        if(fullRect.width() <= 0 || fullRect.height() <= 0){
             return;
         }
         Bitmap bitmap = obtainBitmap(fullRect.width() / sampleSize, fullRect.height() / sampleSize);
+        if(bitmap == null){
+            return;
+        }
         Canvas canvas = cachedCanvas.get(bitmap);
         if (canvas == null) {
             canvas = new Canvas(bitmap);

--- a/frameanimation/src/main/java/com/github/penfeizhou/animation/decode/FrameSeqDecoder.java
+++ b/frameanimation/src/main/java/com/github/penfeizhou/animation/decode/FrameSeqDecoder.java
@@ -108,8 +108,10 @@ public abstract class FrameSeqDecoder<R extends Reader, W extends Writer> {
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
                     if (ret != null && ret.getAllocationByteCount() >= reuseSize) {
                         iterator.remove();
-                        if (ret.getWidth() != width || ret.getHeight() != height) {
-                            ret.reconfigure(width, height, Bitmap.Config.ARGB_8888);
+                        if ((ret.getWidth() != width || ret.getHeight() != height)) {
+                            if (width > 0 && height > 0) {
+                                ret.reconfigure(width, height, Bitmap.Config.ARGB_8888);
+                            }
                         }
                         ret.eraseColor(0);
                         return ret;
@@ -125,9 +127,14 @@ public abstract class FrameSeqDecoder<R extends Reader, W extends Writer> {
                 }
             }
 
+            if (width <= 0 || height <= 0) {
+                return null;
+            }
             try {
                 Bitmap.Config config = Bitmap.Config.ARGB_8888;
                 ret = Bitmap.createBitmap(width, height, config);
+            } catch (Exception e) {
+                e.printStackTrace();
             } catch (OutOfMemoryError e) {
                 e.printStackTrace();
             }


### PR DESCRIPTION
Thread Name: 'FrameDecoderExecutor-3'
Back traces starts.
java.lang.IllegalArgumentException: width and height must be > 0
	at android.graphics.Bitmap.reconfigure(Bitmap.java:300)
	at com.github.penfeizhou.animation.decode.FrameSeqDecoder.obtainBitmap(FrameSeqDecoder.java:112)
	at com.github.penfeizhou.animation.webp.decode.WebPDecoder.renderFrame(WebPDecoder.java:154)
	at com.github.penfeizhou.animation.decode.FrameSeqDecoder.step(FrameSeqDecoder.java:505)
	at com.github.penfeizhou.animation.decode.FrameSeqDecoder.access$200(FrameSeqDecoder.java:36)
	at com.github.penfeizhou.animation.decode.FrameSeqDecoder$1.run(FrameSeqDecoder.java:60)
	at android.os.Handler.handleCallback(Handler.java:938)
	at android.os.Handler.dispatchMessage(Handler.java:99)
	at android.os.Looper.loopOnce(Looper.java:233)
	at android.os.Looper.loop(Looper.java:334)
	at android.os.HandlerThread.run(HandlerThread.java:67)
Back traces ends.