### PR TITLE
fix Too fast Animation of APNG

### DIFF
--- a/frameanimation/src/main/java/com/github/penfeizhou/animation/decode/FrameSeqDecoder.java
+++ b/frameanimation/src/main/java/com/github/penfeizhou/animation/decode/FrameSeqDecoder.java
@@ -59,6 +59,7 @@ public abstract class FrameSeqDecoder<R extends Reader, W extends Writer> {
                 long start = System.currentTimeMillis();
                 long delay = step();
                 long cost = System.currentTimeMillis() - start;
+                workerHandler.removeCallbacks(renderTask);
                 workerHandler.postDelayed(this, Math.max(0, delay - cost));
                 for (RenderListener renderListener : renderListeners) {
                     renderListener.onRender(frameBuffer);
@@ -314,6 +315,7 @@ public abstract class FrameSeqDecoder<R extends Reader, W extends Writer> {
         }
         if (getNumPlays() == 0 || !finished) {
             this.frameIndex = -1;
+            workerHandler.removeCallbacks(renderTask);
             renderTask.run();
             for (RenderListener renderListener : renderListeners) {
                 renderListener.onStart();


### PR DESCRIPTION
fix #176 and #183 

复现和修复机型：小米11 android 13
1、Glide 加载本地 apng Drawable
2、at com.github.penfeizhou.animation.decode.FrameSeqDecoder.start(FrameSeqDecoder.java:304)
      at com.github.penfeizhou.animation.FrameAnimationDrawable.innerStart(FrameAnimationDrawable.java:143)
      at com.github.penfeizhou.animation.FrameAnimationDrawable.setVisible(FrameAnimationDrawable.java:272)
      at android.widget.ImageView.updateDrawable(ImageView.java:1077)
      at android.widget.ImageView.setImageDrawable(ImageView.java:604)
触发第一次 FrameSeqDecoder.innerStart
3、at com.github.penfeizhou.animation.decode.FrameSeqDecoder.stop(FrameSeqDecoder.java:392)
      at com.github.penfeizhou.animation.FrameAnimationDrawable.start(FrameAnimationDrawable.java:130)
      at com.bumptech.glide.request.target.ImageViewTarget.maybeUpdateAnimatable(ImageViewTarget.java:133)
触发第一次 stop 和 第二次 innerStart 
4、at com.github.penfeizhou.animation.decode.FrameSeqDecoder.stop(FrameSeqDecoder.java:392)
      at com.github.penfeizhou.animation.FrameAnimationDrawable.innerStop(FrameAnimationDrawable.java:164)
      at com.github.penfeizhou.animation.FrameAnimationDrawable.setVisible(FrameAnimationDrawable.java:275)
      at android.widget.ImageView.onVisibilityAggregated(ImageView.java:1696)
触发第三次 innerStart （第一次 stop 有个延迟的 innerStop 会清除 state 状态，导致第三次的 innerStart 可以成功）
最终有2次 innerStart 触发,  renderTask 的执行周期被加快